### PR TITLE
Added play-services-maps dependency

### DIFF
--- a/Shared/build.gradle
+++ b/Shared/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile 'com.google.android.gms:play-services-wearable:10.0.1'
     compile 'com.google.android.gms:play-services-location:10.0.1'
     compile 'com.google.maps.android:android-maps-utils:0.3.4'
+    compile 'com.google.android.gms:play-services-maps:10.0.1'
 }
 
 // The sample build uses multiple directories to


### PR DESCRIPTION
It's necessary to add `compile 'com.google.android.gms:play-services-maps:10.0.1'` on _Shared/build.gradle_  to compile the app. Without this, is not possible to compile the app, at least on Android Studio.