### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/Wearable/src/main/AndroidManifest.xml
+++ b/Wearable/src/main/AndroidManifest.xml
@@ -40,7 +40,14 @@
 
         <activity
             android:name=".ui.AttractionsActivity"
-            android:label="@string/app_name" />
+            android:label="@string/app_name" >
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+        </activity>
 
         <activity
             android:name="android.support.wearable.activity.ConfirmationActivity"


### PR DESCRIPTION
Wearable module require a launch activity to run. There is no intent filter mentioned here which tells the app which activity to launch first time. So adding the required intent filter as android studio is showing error while launching the wearable module.